### PR TITLE
Fix IllegalArgument exception with multiple constructors

### DIFF
--- a/compiler/src/main/java/com/juul/pommel/compiler/PommelProcessor.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/PommelProcessor.kt
@@ -110,6 +110,8 @@ class PommelProcessor : AbstractProcessor() {
             valid = false
         }
 
+        if (!valid) return null
+
         val constructor = constructors.single()
         if (Modifier.PRIVATE in constructor.modifiers) {
             error("@Inject constructor must not be private.", constructor)

--- a/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
@@ -53,7 +53,7 @@ class PommelWriter(
                         addParameter(it.qualifiedType, it.simpleName.toString())
                     }
                     .addStatement(
-                        "return new \$T$>(\n\$L)$<", targetType,
+                        "return new \$T(\n\$L)", targetType,
                         parameters.map { CodeBlock.of("\$N", it.simpleName) }.joinToCode(",\n")
                     )
                     .build()

--- a/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
@@ -53,7 +53,7 @@ class PommelWriter(
                         addParameter(it.qualifiedType, it.simpleName.toString())
                     }
                     .addStatement(
-                        "return new \$T(\n\$L)", targetType,
+                        "return new \$T$>(\n\$L)$<", targetType,
                         parameters.map { CodeBlock.of("\$N", it.simpleName) }.joinToCode(",\n")
                     )
                     .build()

--- a/tests/src/test/java/com/juul/pommel/test/PommelProcessorTests.kt
+++ b/tests/src/test/java/com/juul/pommel/test/PommelProcessorTests.kt
@@ -1059,6 +1059,37 @@ class PommelProcessorTests {
         )
     }
 
+    @Test
+    fun `multiple inject constructor fails`() {
+        val result = compile(
+            SourceFile.kotlin(
+                "source.kt",
+                """
+          package test 
+          
+        
+          
+          import com.juul.pommel.annotations.SoloModule
+          import javax.inject.Inject
+          import javax.inject.Scope
+          
+          @Scope
+          annotation class CustomScope
+          
+          @SoloModule
+          @CustomScope
+          class SampleClass @Inject constructor(private val a: Int) {
+              
+              @Inject constructor(): this(10) 
+          }
+          """
+            )
+        )
+
+        assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains("error: Multiple constructors marked with @Inject annotated found")
+    }
+
     private fun prepareCompilation(vararg sourceFiles: SourceFile): KotlinCompilation {
         return KotlinCompilation().apply {
             workingDir = temporaryFolder.root

--- a/tests/src/test/java/com/juul/pommel/test/PommelProcessorTests.kt
+++ b/tests/src/test/java/com/juul/pommel/test/PommelProcessorTests.kt
@@ -1088,6 +1088,7 @@ class PommelProcessorTests {
 
         assertEquals(result.exitCode, KotlinCompilation.ExitCode.COMPILATION_ERROR)
         assertThat(result.messages).contains("error: Multiple constructors marked with @Inject annotated found")
+        assertThat(result.messages).doesNotContain("An exception occurred: java.lang.IllegalArgumentException: List has more than one element")
     }
 
     private fun prepareCompilation(vararg sourceFiles: SourceFile): KotlinCompilation {


### PR DESCRIPTION
`contructor.single()` will throw an IllegalArgument exception if the collections contains more than one item. We don't want to crash kapt, we should instead print the compilation error and return null from the function.  