### PR TITLE
Use @Binds when providing an interface or abstract class

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,12 +153,10 @@ Will generate the equivalent of:
 ```java
 @Module
 public class SampleClass_SoloModule {
-  @Provides
+  @Binds
   @Singleton
   @Named("sample")
-  public MyInterface provides_SampleClass(@Named("a") int a, String b) {
-    return new SampleClass(a, b);
-  }
+  public abstract MyInterface provides_SampleClass(SampleClass sampleClass);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Will generate the equivalent of:
 ```java
 @Module
 @InstallIn(ApplicationComponent.class)
-public class SampleClass_SoloModule {
+public abstract class SampleClass_SoloModule {
   @Provides
   @Singleton
-  public SampleClass provides_SampleClass(@Named("a") int a, String b) {
+  public static SampleClass provides_SampleClass(@Named("a") int a, String b) {
     return new SampleClass(a, b);
   }
 }
@@ -75,10 +75,10 @@ Will generate the equivalent of:
 
 ```java
 @Module
-public class SampleClass_SoloModule {
+public abstract class SampleClass_SoloModule {
   @Provides
   @Singleton
-  public SampleClass provides_SampleClass(@Named("a") int a, String b) {
+  public static SampleClass provides_SampleClass(@Named("a") int a, String b) {
     return new SampleClass(a, b);
   }
 }
@@ -101,10 +101,10 @@ Will generate the equivalent of:
 
 ```java
 @Module
-public class SampleClass_SoloModule {
+public abstract class SampleClass_SoloModule {
   @Provides
   @Singleton
-  public SampleClass provides_SampleClass(@Named("a") int a, String b) {
+  public static SampleClass provides_SampleClass(@Named("a") int a, String b) {
     return new SampleClass(a, b);
   }
 }
@@ -127,12 +127,10 @@ Will generate the equivalent of:
 
 ```java
 @Module
-public class SampleClass_SoloModule {
-  @Provides
+public abstract class SampleClass_SoloModule {
+  @Binds
   @Singleton
-  public MyInterface provides_SampleClass(@Named("a") int a, String b) {
-    return new SampleClass(a, b);
-  }
+  public abstract MyInterface binds_SampleClass(SampleClass sampleClass);
 }
 ```
 
@@ -144,7 +142,7 @@ Pommel was intended to be used for testing with Dagger-Hilt. Simply mark the ele
 @SoloModule
 @Singleton
 class MyService @Inject constructor(
-    @Named("a" ) val a: Int,
+    @Named("a") val a: Int,
     val b: String
 )
 ```

--- a/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
@@ -44,15 +44,13 @@ class PommelWriter(
                     )
                 }
             }
-            .apply {
-                addMethod(
-                    if (targetType == binds) {
-                        writeProvidesMethod()
-                    } else {
-                        writeBindsMethod()
-                    }
-                )
-            }
+            .addMethod(
+                if (targetType == binds) {
+                    writeProvidesMethod()
+                } else {
+                    writeBindsMethod()
+                }
+            )
             .build()
     }
 

--- a/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
@@ -66,8 +66,8 @@ class PommelWriter(
     private fun writeProvidesMethod(): MethodSpec {
         return MethodSpec.methodBuilder(targetType.rawClassName().provideFunctionName())
             .addAnnotation(PROVIDES)
-            .apply { scope?.let { addAnnotation(it) } }
-            .apply { qualifier?.let { addAnnotation(it) } }
+            .apply { if (scope != null) addAnnotation(scope) }
+            .apply { if (qualifier != null) addAnnotation(qualifier) }
             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
             .returns(binds)
             .applyEach(parameters) {
@@ -83,8 +83,8 @@ class PommelWriter(
     private fun writeBindsMethod(): MethodSpec {
         return MethodSpec.methodBuilder(targetType.rawClassName().bindsFunctionName())
             .addAnnotation(BINDS)
-            .apply { scope?.let { addAnnotation(it) } }
-            .apply { qualifier?.let { addAnnotation(it) } }
+            .apply { if (scope != null) addAnnotation(scope) }
+            .apply { if (qualifier != null) addAnnotation(qualifier) }
             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
             .returns(binds)
             .addParameter(targetType, targetType.rawClassName().simpleName().decapitalize())

--- a/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
@@ -54,6 +54,9 @@ class PommelWriter(
                 }
             }
             .addMethod(
+                // if the value of binds is equal to the target class annotated with @SoloModule
+                // then we generate a provides method otherwise the value of the target class is a
+                // implementation of binds and we generate a binds method
                 if (targetType == binds) {
                     writeProvidesMethod()
                 } else {

--- a/tests/src/test/java/com/juul/pommel/test/PommelProcessorTests.kt
+++ b/tests/src/test/java/com/juul/pommel/test/PommelProcessorTests.kt
@@ -45,9 +45,9 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
-           public SampleClass provides_test_SampleClass() {
+           public static SampleClass provides_test_SampleClass() {
              return new SampleClass(
                  );
            }
@@ -83,9 +83,9 @@ class PommelProcessorTests {
          import dagger.Provides;
          
          @Module
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
-           public SampleClass provides_test_SampleClass() {
+           public static SampleClass provides_test_SampleClass() {
              return new SampleClass(
                  );
            }
@@ -127,10 +127,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
-           public SampleClass provides_test_SampleClass() {
+           public static SampleClass provides_test_SampleClass() {
              return new SampleClass(
                  );
            }
@@ -172,10 +172,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ActivityRetainedComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @ActivityRetainedScoped
-           public SampleClass provides_test_SampleClass() {
+           public static SampleClass provides_test_SampleClass() {
              return new SampleClass(
                  );
            }
@@ -217,10 +217,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ActivityComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @ActivityScoped
-           public SampleClass provides_test_SampleClass() {
+           public static SampleClass provides_test_SampleClass() {
              return new SampleClass(
                  );
            }
@@ -262,10 +262,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(FragmentComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @FragmentScoped
-           public SampleClass provides_test_SampleClass() {
+           public static SampleClass provides_test_SampleClass() {
              return new SampleClass(
                  );
            }
@@ -307,10 +307,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ServiceComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @ServiceScoped
-           public SampleClass provides_test_SampleClass() {
+           public static SampleClass provides_test_SampleClass() {
              return new SampleClass(
                  );
            }
@@ -352,10 +352,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ViewComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @ViewScoped
-           public SampleClass provides_test_SampleClass() {
+           public static SampleClass provides_test_SampleClass() {
              return new SampleClass(
                  );
            }
@@ -427,10 +427,10 @@ class PommelProcessorTests {
          import dagger.Provides;
          
          @Module
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @CustomScope
-           public SampleClass provides_test_SampleClass() {
+           public static SampleClass provides_test_SampleClass() {
              return new SampleClass(
                  );
            }
@@ -477,10 +477,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
-           public SampleClass provides_test_SampleClass(int a, String b, double c) {
+           public static SampleClass provides_test_SampleClass(int a, String b, double c) {
              return new SampleClass(
                  a,
                  b,
@@ -532,10 +532,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
-           public SampleClass provides_test_SampleClass(@Named("a") int a, String b, double c,
+           public static SampleClass provides_test_SampleClass(@Named("a") int a, String b, double c,
                @Named("b") byte d) {
              return new SampleClass(
                  a,
@@ -565,7 +565,7 @@ class PommelProcessorTests {
           @SoloModule(AbstractClass::class)
           @Singleton
           class SampleClass @Inject constructor(
-              @Named("a" ) val a: Int,
+              @Named("a") val a: Int,
               val b: String,
               val c: Double,
               @Named("b") val d: Byte
@@ -581,27 +581,18 @@ class PommelProcessorTests {
             """
          package test;
 
+         import dagger.Binds;
          import dagger.Module;
-         import dagger.Provides;
          import dagger.hilt.InstallIn;
          import dagger.hilt.android.components.ApplicationComponent;
-         import java.lang.String;
-         import javax.inject.Named;
          import javax.inject.Singleton;
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
-           @Provides
+         public abstract class SampleClass_SoloModule {
+           @Binds
            @Singleton
-           public AbstractClass provides_test_SampleClass(@Named("a") int a, String b, double c,
-               @Named("b") byte d) {
-             return new SampleClass(
-                 a,
-                 b,
-                 c,
-                 d);
-           }
+           public abstract AbstractClass binds_test_SampleClass(SampleClass sampleClass);
          }"""
         )
     }
@@ -640,27 +631,18 @@ class PommelProcessorTests {
             """
          package test;
 
+         import dagger.Binds;
          import dagger.Module;
-         import dagger.Provides;
          import dagger.hilt.InstallIn;
          import dagger.hilt.android.components.ApplicationComponent;
-         import java.lang.String;
-         import javax.inject.Named;
          import javax.inject.Singleton;
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
-           @Provides
+         public abstract class SampleClass_SoloModule {
+           @Binds
            @Singleton
-           public TestInterface provides_test_SampleClass(@Named("a") int a, String b, double c,
-               @Named("b") byte d) {
-             return new SampleClass(
-                 a,
-                 b,
-                 c,
-                 d);
-           }
+           public abstract TestInterface binds_test_SampleClass(SampleClass sampleClass);
          }"""
         )
     }
@@ -701,27 +683,18 @@ class PommelProcessorTests {
             """
          package test;
 
+         import dagger.Binds;
          import dagger.Module;
-         import dagger.Provides;
          import dagger.hilt.InstallIn;
          import dagger.hilt.android.components.ApplicationComponent;
-         import java.lang.String;
-         import javax.inject.Named;
          import javax.inject.Singleton;
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
-           @Provides
+         public abstract class SampleClass_SoloModule {
+           @Binds
            @Singleton
-           public SecondTestInterface provides_test_SampleClass(@Named("a") int a, String b, double c,
-               @Named("b") byte d) {
-             return new SampleClass(
-                 a,
-                 b,
-                 c,
-                 d);
-           }
+           public abstract SecondTestInterface binds_test_SampleClass(SampleClass sampleClass);
          }"""
         )
     }
@@ -770,10 +743,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
-           public SampleClass provides_test_SampleClass(@Named("a") int a, String b, double c,
+           public static SampleClass provides_test_SampleClass(@Named("a") int a, String b, double c,
                @Named("b") byte d) {
              return new SampleClass(
                  a,
@@ -831,10 +804,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
-           public SampleClass provides_test_SampleClass(@Named("a") int a, String b, double c,
+           public static SampleClass provides_test_SampleClass(@Named("a") int a, String b, double c,
                @Named("b") byte d) {
              return new SampleClass(
                  a,
@@ -892,10 +865,10 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
+         public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
-           public SampleClass provides_test_SampleClass(@Named("a") int a, String b, double c,
+           public static SampleClass provides_test_SampleClass(@Named("a") int a, String b, double c,
                @Named("b") byte d) {
              return new SampleClass(
                  a,
@@ -943,27 +916,18 @@ class PommelProcessorTests {
             """
          package test;
 
+         import dagger.Binds;
          import dagger.Module;
-         import dagger.Provides;
          import dagger.hilt.InstallIn;
          import dagger.hilt.android.components.ApplicationComponent;
-         import java.lang.String;
-         import javax.inject.Named;
          import javax.inject.Singleton;
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
-           @Provides
+         public abstract class SampleClass_SoloModule {
+           @Binds
            @Singleton
-           public AbstractClass provides_test_SampleClass(@Named("a") int a, String b, double c,
-               @Named("b") byte d) {
-             return new SampleClass(
-                 a,
-                 b,
-                 c,
-                 d);
-           }
+           public abstract AbstractClass binds_test_SampleClass(SampleClass sampleClass);
          }"""
         )
     }
@@ -1049,9 +1013,9 @@ class PommelProcessorTests {
          
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass${'$'}InnerClass_SoloModule {
+         public abstract class SampleClass${'$'}InnerClass_SoloModule {
            @Provides
-           public SampleClass.InnerClass provides_test_SampleClass${'$'}InnerClass() {
+           public static SampleClass.InnerClass provides_test_SampleClass${'$'}InnerClass() {
              return new SampleClass.InnerClass(
                  );
            }

--- a/tests/src/test/java/com/juul/pommel/test/PommelProcessorTests.kt
+++ b/tests/src/test/java/com/juul/pommel/test/PommelProcessorTests.kt
@@ -1134,11 +1134,10 @@ class PommelProcessorTests {
             """
          package test;
 
+         import dagger.Binds;
          import dagger.Module;
-         import dagger.Provides;
          import dagger.hilt.InstallIn;
          import dagger.hilt.android.components.ApplicationComponent;
-         import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Named;
          import javax.inject.Singleton;
@@ -1146,18 +1145,11 @@ class PommelProcessorTests {
          $GENERATED_ANNOTATION
          @Module
          @InstallIn(ApplicationComponent.class)
-         public class SampleClass_SoloModule {
-           @Provides
+         public abstract class SampleClass_SoloModule {
+           @Binds
            @Singleton
            @Named("test")
-           public TestInterface provides_test_SampleClass(@Named("a") int a, String b, double c,
-               @Named("b") byte d) {
-             return new SampleClass(
-                 a,
-                 b,
-                 c,
-                 d);
-           }
+           public abstract TestInterface binds_test_SampleClass(SampleClass sampleClass);
          }"""
         )
     }


### PR DESCRIPTION
Currently when Pommel generates a module that binds an interface it will generate the following 

```java
@Module 
public class Sample_SoloModule {
    @Provides 
    public MyInterface provides_sample() {
        return new Sample();
    }
}
```

but with Dagger we can take advantage of the `@Binds` annotation as it is meant to be used when return an injected parameter 

> @Binds methods are a drop-in replacement for Provides methods that simply return an injected parameter. Prefer @Binds because the generated implementation is likely to be more efficient.

So we can generate the following instead 

```java
@Module 
public abstract class Sample_SoloModule {
    @Binds 
    public abstract MyInterface provides_sample(Sample sample);
}
```

since `@Binds` methods need to be in an abstract class, all generated modules are now marked as abstract. This means that modules that generate a concrete implementation now generate a static method as follows 


```java
@Module 
public abstract class Sample_SoloModule {
    @Provides 
    public static Sample provides_sample() {
        return new Sample();
    }
}
```
non-static methods are not allowed in an abstract module but we should always prefer to generate the static method as to not have to create an instance of the generate module class 



