### PR TITLE
Add support for qualifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,34 @@ public class SampleClass_SoloModule {
 }
 ```
 
+You can annotate your class with a qualifier:
+
+```kotlin
+interface MyInterface
+
+@SoloModule(MyInterface::class)
+@Singleton
+@Named("sample")
+class SampleClass @Inject constructor(
+    @Named("a") val a: Int,
+    val b: String
+) : MyInterface
+```
+
+Will generate the equivalent of:
+
+```java
+@Module
+public class SampleClass_SoloModule {
+  @Provides
+  @Singleton
+  @Named("sample")
+  public MyInterface provides_SampleClass(@Named("a") int a, String b) {
+    return new SampleClass(a, b);
+  }
+}
+```
+
 # Testing
 
 Pommel was intended to be used for testing with Dagger-Hilt. Simply mark the element you'd like to replace in test with `@SoloModule`, then uninstall the resulting generated module in your test to provide your own test implementation:

--- a/compiler/src/main/java/com/juul/pommel/compiler/PommelProcessor.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/PommelProcessor.kt
@@ -7,6 +7,7 @@ import com.juul.pommel.compiler.internal.ACTIVITY_SCOPED
 import com.juul.pommel.compiler.internal.FRAGMENT_SCOPED
 import com.juul.pommel.compiler.internal.INJECT_ANNOTATION
 import com.juul.pommel.compiler.internal.JAVA_VOID
+import com.juul.pommel.compiler.internal.QUALIFIER_ANNOTATION
 import com.juul.pommel.compiler.internal.SCOPE_ANNOTATION
 import com.juul.pommel.compiler.internal.SERVICE_SCOPED
 import com.juul.pommel.compiler.internal.SINGLETON_SCOPED
@@ -132,6 +133,12 @@ class PommelProcessor : AbstractProcessor() {
             AnnotationSpec.get(it)
         }
 
+        val qualifier = annotationMirrors.find {
+            it.annotationType.asElement().hasAnnotation(QUALIFIER_ANNOTATION)
+        }?.let {
+            AnnotationSpec.get(it)
+        }
+
         val component = if (scope != null) {
             when (scope.type.toString()) {
                 SINGLETON_SCOPED -> applicationComponent
@@ -157,6 +164,7 @@ class PommelProcessor : AbstractProcessor() {
             moduleType = this,
             targetType = this.asType().toTypeName(),
             scope = scope,
+            qualifier = qualifier,
             component = component,
             parameters = constructor.parameters,
             install = install,

--- a/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/PommelWriter.kt
@@ -1,5 +1,6 @@
 package com.juul.pommel.compiler
 
+import com.juul.pommel.compiler.internal.QUALIFIER_ANNOTATION
 import com.juul.pommel.compiler.internal.applyEach
 import com.juul.pommel.compiler.internal.hasAnnotation
 import com.juul.pommel.compiler.internal.toTypeName
@@ -22,6 +23,7 @@ class PommelWriter(
     val moduleType: TypeElement,
     val targetType: TypeName,
     val scope: AnnotationSpec?,
+    val qualifier: AnnotationSpec?,
     val component: ClassName?,
     val parameters: List<VariableElement>,
     val install: Boolean,
@@ -47,6 +49,7 @@ class PommelWriter(
                 MethodSpec.methodBuilder(targetType.rawClassName().provideFunctionName())
                     .addAnnotation(PROVIDES)
                     .apply { scope?.let { addAnnotation(it) } }
+                    .apply { qualifier?.let { addAnnotation(it) } }
                     .addModifiers(Modifier.PUBLIC)
                     .returns(binds)
                     .applyEach(parameters) {
@@ -96,7 +99,7 @@ private val VariableElement.qualifiedType: TypeName
 
 private fun VariableElement.qualifier(): AnnotationSpec? {
     return annotationMirrors.find {
-        it.annotationType.asElement().hasAnnotation("javax.inject.Qualifier")
+        it.annotationType.asElement().hasAnnotation(QUALIFIER_ANNOTATION)
     }?.let { AnnotationSpec.get(it) }
 }
 

--- a/compiler/src/main/java/com/juul/pommel/compiler/internal/Utils.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/internal/Utils.kt
@@ -11,6 +11,7 @@ import javax.lang.model.type.TypeMirror
 
 internal const val SCOPE_ANNOTATION: String = "javax.inject.Scope"
 internal const val INJECT_ANNOTATION: String = "javax.inject.Inject"
+internal const val QUALIFIER_ANNOTATION: String = "javax.inject.Qualifier"
 internal const val JAVA_VOID: String = "java.lang.Void"
 
 internal const val SINGLETON_SCOPED: String = "javax.inject.Singleton"

--- a/sample/src/androidTest/java/com/juul/pommel/sample/PommelSampleTest.kt
+++ b/sample/src/androidTest/java/com/juul/pommel/sample/PommelSampleTest.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.testing.UninstallModules
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import javax.inject.Named
 
 @RunWith(AndroidJUnit4::class)
 @HiltAndroidTest
@@ -33,6 +34,7 @@ class PommelSampleTest {
 
     @BindValue
     @JvmField
+    @field:Named("NameProvider")
     val testNameProvider: NameProvider = SpanishNameProvider()
 
     @BindValue

--- a/sample/src/main/java/com/juul/pommel/sample/EnglishNameProvider.kt
+++ b/sample/src/main/java/com/juul/pommel/sample/EnglishNameProvider.kt
@@ -2,8 +2,10 @@ package com.juul.pommel.sample
 
 import com.juul.pommel.annotations.SoloModule
 import javax.inject.Inject
+import javax.inject.Named
 
 @SoloModule(NameProvider::class)
+@Named("NameProvider")
 class EnglishNameProvider @Inject constructor() : NameProvider {
 
     override fun name(): String {

--- a/sample/src/main/java/com/juul/pommel/sample/Greeter.kt
+++ b/sample/src/main/java/com/juul/pommel/sample/Greeter.kt
@@ -2,11 +2,12 @@ package com.juul.pommel.sample
 
 import com.juul.pommel.annotations.SoloModule
 import javax.inject.Inject
+import javax.inject.Named
 
 @SoloModule
 class Greeter @Inject constructor(
     private val welcomeProvider: WelcomeProvider,
-    private val nameProvider: NameProvider
+    @Named("NameProvider") private val nameProvider: NameProvider
 ) {
 
     fun greet(): String {

--- a/sample/src/test/java/com/juul/pommel/sample/PommelSampleUnitTest.kt
+++ b/sample/src/test/java/com/juul/pommel/sample/PommelSampleUnitTest.kt
@@ -15,6 +15,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import javax.inject.Named
 
 /**
  * Roboeletric has limitation with Dagger-Hilt. Running this test from the IDE will fail.
@@ -45,6 +46,7 @@ class PommelSampleUnitTest {
 
     @BindValue
     @JvmField
+    @field:Named("NameProvider")
     val frenchNameProvider: NameProvider = FrenchNameProvider()
 
     @Test


### PR DESCRIPTION
Pommel does not support qualifiers. This can be problematic when you have an interface with multiple implementation. Currently you can only bind one implementation of an interface with Pommel but with this change we can support qualifiers annotated on a class

```kotlin
interface Service 

@SoloModule(Service::class)
@Named("RestService")
class RestService @Inject constructor() : Service
```

Will generate the equivalent of:

```java
@Module 
@InstallIn(ApplicationComponent.class)
public class RestService_SoloModule {
    @Provides 
    @Named("RestService")
    public Service provides_RestService() {
        return new RestService();
    }
}
```