### PR TITLE
Update Dagger to 2.28.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Will generate the equivalent of:
 
 ```java
 @Module
-@InstallIn(ApplicationComponent.class)
+@InstallIn(SingletonComponent.class)
 public abstract class SampleClass_SoloModule {
   @Provides
   @Singleton
@@ -103,7 +103,7 @@ Will generate the equivalent of:
 
 ```java
 @Module
-@InstallIn(ApplicationComponent.class)
+@InstallIn(SingletonComponent.class)
 public abstract class SampleClass_SoloModule {
   @Provides
   @Singleton
@@ -130,7 +130,7 @@ Will generate the equivalent of:
 
 ```java
 @Module
-@InstallIn(ApplicationComponent.class)
+@InstallIn(SingletonComponent.class)
 public abstract class SampleClass_SoloModule {
   @Binds
   @Singleton
@@ -156,7 +156,7 @@ Will generate the equivalent of:
 
 ```java
 @Module
-@InstallIn(ApplicationComponent.class)
+@InstallIn(SingletonComponent.class)
 public abstract class SampleClass_SoloModule {
   @Binds
   @Singleton
@@ -178,7 +178,7 @@ Will generate the equivalent of:
 
 ```java
 @Module
-@InstallIn(ApplicationComponent.class)
+@InstallIn(SingletonComponent.class)
 public abstract class name_SoloModule {
   @Provides
   @Singleton
@@ -206,7 +206,7 @@ Will generate the equivalent of:
 
 ```java
 @Module
-@InstallIn(ApplicationComponent.class)
+@InstallIn(SingletonComponent.class)
 public abstract class name_SoloModule {
   @Provides
   @Singleton
@@ -235,7 +235,7 @@ Will generate the equivalent of:
 
 ```java
 @Module
-@InstallIn(ApplicationComponent.class)
+@InstallIn(SingletonComponent.class)
 public abstract class name_SoloModule {
   @Provides
   @Singleton
@@ -287,7 +287,7 @@ constructor annotated with `@Inject`. All parameters passed into the constructor
 Pommel expects all functions annotated with `@SoloModule` to be `static` due to the fact the generated module needs to call the annotated function.
 As a result Pommel currently only supports top level functions and functions in a top level `object` that are annotated with `@JvmStatic`. `static` functions within a `companion object` are currently not supported.
 
-Pommel will install your dependency into the correct component given the scope your dependency was annotated with. If you do not provide a scope to the dependency Pommel will by default install into the ApplicationComponent.
+Pommel will install your dependency into the correct component given the scope your dependency was annotated with. If you do not provide a scope to the dependency Pommel will by default install into the SingletonComponent.
 If you annotate your dependency with a custom scope you will get a compiler error as Pommel does currently not support being installed into a custom component.
 You can get around this current limitation by setting the `install` parameter to false and pommel will skip generating the `InstallIn` annotation on your module.
 The downside is you now have to manually include the generated module into your dagger graph rather the module being auto installed in for you.

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 buildscript {
     ext.versions = [
         'kotlin'    : '1.3.72',
-        'dagger'    : '2.28.1',
-        'daggerHilt': '2.28.1-alpha',
+        'dagger'    : '2.28.3',
+        'daggerHilt': '2.28.3-alpha',
         'incap'     : '0.2',
     ]
 

--- a/compiler/src/main/java/com/juul/pommel/compiler/ElementExtensions.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/ElementExtensions.kt
@@ -56,7 +56,7 @@ internal fun Element.toSoloModuleParams(): SoloModuleParams {
 
     val component = if (scope != null) {
         when (scope.type.toString()) {
-            SINGLETON_SCOPED -> applicationComponent
+            SINGLETON_SCOPED -> singletonComponent
             ACTIVITY_RETAINED_SCOPED -> activityRetainedComponent
             ACTIVITY_SCOPED -> activityComponent
             FRAGMENT_SCOPED -> fragmentComponent
@@ -65,7 +65,7 @@ internal fun Element.toSoloModuleParams(): SoloModuleParams {
             else -> null // custom scope
         }
     } else {
-        applicationComponent
+        singletonComponent
     }
 
     return SoloModuleParams(

--- a/compiler/src/main/java/com/juul/pommel/compiler/Names.kt
+++ b/compiler/src/main/java/com/juul/pommel/compiler/Names.kt
@@ -2,7 +2,7 @@ package com.juul.pommel.compiler
 
 import com.squareup.javapoet.ClassName
 
-internal val applicationComponent: ClassName = ClassName.get("dagger.hilt.android.components", "ApplicationComponent")
+internal val singletonComponent: ClassName = ClassName.get("dagger.hilt.components", "SingletonComponent")
 internal val activityComponent: ClassName = ClassName.get("dagger.hilt.android.components", "ActivityComponent")
 internal val activityRetainedComponent: ClassName = ClassName.get("dagger.hilt.android.components", "ActivityRetainedComponent")
 internal val fragmentComponent: ClassName = ClassName.get("dagger.hilt.android.components", "FragmentComponent")

--- a/tests/src/test/java/com/juul/pommel/test/PommelProcessorClassTests.kt
+++ b/tests/src/test/java/com/juul/pommel/test/PommelProcessorClassTests.kt
@@ -35,12 +35,12 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Provides
            public static SampleClass provides_test_SampleClass() {
@@ -120,13 +120,13 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          import javax.inject.Singleton;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
@@ -483,14 +483,14 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Singleton;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
@@ -539,7 +539,7 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Named;
@@ -547,7 +547,7 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
@@ -600,13 +600,13 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Binds;
          import dagger.Module;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          import javax.inject.Singleton;
 
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Binds
            @Singleton
@@ -652,13 +652,13 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Binds;
          import dagger.Module;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          import javax.inject.Singleton;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Binds
            @Singleton
@@ -706,13 +706,13 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Binds;
          import dagger.Module;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          import javax.inject.Singleton;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Binds
            @Singleton
@@ -758,7 +758,7 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Named;
@@ -766,7 +766,7 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
@@ -821,7 +821,7 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Named;
@@ -829,7 +829,7 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
@@ -884,7 +884,7 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Named;
@@ -892,7 +892,7 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Provides
            @Singleton
@@ -947,13 +947,13 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Binds;
          import dagger.Module;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          import javax.inject.Singleton;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Binds
            @Singleton
@@ -1039,12 +1039,12 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass${'$'}InnerClass_SoloModule {
            @Provides
            public static SampleClass.InnerClass provides_test_SampleClass${'$'}InnerClass() {
@@ -1125,14 +1125,14 @@ class PommelProcessorClassTests : PommelProcessorTests() {
          import dagger.Binds;
          import dagger.Module;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          import javax.inject.Named;
          import javax.inject.Singleton;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class SampleClass_SoloModule {
            @Binds
            @Singleton

--- a/tests/src/test/java/com/juul/pommel/test/PommelProcessorFunctionTests.kt
+++ b/tests/src/test/java/com/juul/pommel/test/PommelProcessorFunctionTests.kt
@@ -41,13 +41,13 @@ class PommelProcessorFunctionTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class baseUrl_SoloModule {
            @Provides
            public static String provides_test_SourceKt_baseUrl() {
@@ -139,14 +139,14 @@ class PommelProcessorFunctionTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Singleton;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class baseUrl_SoloModule {
            @Provides
            @Singleton
@@ -531,14 +531,14 @@ class PommelProcessorFunctionTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Named;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class baseUrl_SoloModule {
            @Provides
            public static String provides_test_SourceKt_baseUrl(int a, @Named("b") byte b) {
@@ -636,14 +636,14 @@ class PommelProcessorFunctionTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Named;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class baseUrl_SoloModule {
            @Provides
            public static String provides_test_Sample_baseUrl(int a, @Named("b") byte b) {
@@ -688,14 +688,14 @@ class PommelProcessorFunctionTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import java.lang.String;
          import javax.annotation.Generated;
          import javax.inject.Named;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class baseUrl_SoloModule {
            @Provides
            public static String provides_test_HiltFunctions_baseUrl(int a, @Named("b") byte b) {
@@ -739,12 +739,12 @@ class PommelProcessorFunctionTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class sampleClass_SoloModule {
            @Provides
            public static TestInterface provides_test_SourceKt_sampleClass() {
@@ -791,13 +791,13 @@ class PommelProcessorFunctionTests : PommelProcessorTests() {
          import dagger.Module;
          import dagger.Provides;
          import dagger.hilt.InstallIn;
-         import dagger.hilt.android.components.ApplicationComponent;
+         import dagger.hilt.components.SingletonComponent;
          import javax.annotation.Generated;
          import javax.inject.Named;
          
          $GENERATED_ANNOTATION
          @Module
-         @InstallIn(ApplicationComponent.class)
+         @InstallIn(SingletonComponent.class)
          public abstract class sampleClass_SoloModule {
            @Provides
            @Named("sample")


### PR DESCRIPTION
Update Dagger to 2.28.3 

`ApplicationComponent` has been renamed to `SingletonComponent` which was done as part of  a plan to allow usage of Hilt in non Android module 

You can read about about that changes here 

https://github.com/google/dagger/releases/tag/dagger-2.28.2
https://github.com/google/dagger/releases/tag/dagger-2.28.3
